### PR TITLE
Use JDK 21 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: coursier/cache-action@v6
     - uses: coursier/setup-action@v1
       with:
-        jvm: 17
+        jvm: 21
     - name: Test
       run: ./mill -i __.test
     - name: Validate README
@@ -34,7 +34,7 @@ jobs:
     - uses: coursier/cache-action@v6
     - uses: coursier/setup-action@v1
       with:
-        jvm: 17
+        jvm: 21
     - name: MiMA
       run: ./mill -i __.mimaReportBinaryIssues
 
@@ -49,7 +49,7 @@ jobs:
     - uses: coursier/cache-action@v6
     - uses: coursier/setup-action@v1
       with:
-        jvm: 17
+        jvm: 21
     - run: .github/scripts/gpg-setup.sh
       env:
         PGP_SECRET: ${{ secrets.PUBLISH_SECRET_KEY }}


### PR DESCRIPTION
Published JARs are still compatible with Java 8, as we pass `-release 8` to scalac